### PR TITLE
Pubsub persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
  "serde_urlencoded",
  "sha-1",
  "slab",
- "time",
+ "time 0.2.26",
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "socket2",
- "time",
+ "time 0.2.26",
  "tinyvec",
  "url",
 ]
@@ -493,6 +493,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "time 0.1.44",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "const_fn"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,7 +525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
 dependencies = [
  "percent-encoding",
- "time",
+ "time 0.2.26",
  "version_check",
 ]
 
@@ -820,7 +834,7 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi 0.10.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1165,6 +1179,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1402,6 +1435,7 @@ dependencies = [
  "actix-utils 3.0.0",
  "actix-web",
  "bincode",
+ "chrono",
  "env_logger",
  "futures",
  "local-channel",
@@ -1668,6 +1702,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "time"
 version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08a8cbfbf47955132d0202d1662f49b2423ae35862aee471f3ba4b133358f372"
@@ -1927,9 +1972,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
+version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ log = "0.4.0"
 env_logger = "0.8.3"
 sled = "0.34.6"
 bincode = "1.3.3"
+chrono = { version = "0.4.19", features = ["serde"] }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -43,7 +43,7 @@ async fn queue_streaming(info: web::Path<QueueInfo>, data: web::Data<Mutex<crate
 
     let mut data = data.lock().unwrap();
     match data.append_subscriber(info.queuename.clone()) {
-        Ok(sb) =>  return Ok(HttpResponse::Ok().streaming(sb)),
+        Ok(sb) =>  return Ok(HttpResponse::Ok().content_type("application/json").streaming(sb)),
         Err(_e) =>  return Ok(HttpResponse::BadRequest().content_type("application/json").body(format!("msg: error subscribing {:?}", &info.queuename))),
     };
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -102,6 +102,26 @@ impl PersistenceManager {
 
     }
 
+    pub fn pop_item_by_key(&mut self, queue_name: String, key: String) -> Result<Box<Vec<u8>>, String> {
+        let db = self.databases.get(&queue_name.clone());
+        // fetch or create the db handler
+        let dbc = match db.clone() {
+            Some(_) => (db),
+            None => {
+                self.load_or_create_database(queue_name.clone()).unwrap();
+                self.databases.get(&queue_name)
+            },
+        };
+
+        let dbc = dbc.unwrap();
+
+        match dbc.get(key).unwrap() {
+            Some(value) => Ok(Box::new(bincode::deserialize(value.as_ref()).unwrap())),
+            None => Err("Empty queue table".to_string()),
+        }
+
+    }
+
     pub fn load_or_create_database(&mut self, queue_name: String) -> Result<bool, String> {
         let mut pb = PathBuf::new();
         pb.push(&self.path);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -5,7 +5,7 @@ use std::sync::{Mutex, Arc};
 use tokio::sync::mpsc::UnboundedSender;
 use actix_web::web::Bytes;
 use uuid::Uuid;
-use std::time::SystemTime;
+use chrono::{Local, DateTime};
 use tokio::sync::mpsc::unbounded_channel;
 use tokio::sync::mpsc::error::SendError;
 
@@ -15,7 +15,7 @@ use tokio::sync::mpsc::error::SendError;
 pub struct QueueMessageEnvelope {
     pub id: Uuid,
     pub body: String,
-    pub created_at: SystemTime,
+    pub created_at: DateTime<Local>,
 }
 
 
@@ -55,7 +55,8 @@ impl QueueManager {
     pub fn push_message(&mut self, queue_name: String, message: String, create_queue: bool) -> Result<String, String> {
 
         let uuid = Uuid::new_v4();
-        let payload = QueueMessageEnvelope {id: uuid, body: message, created_at: SystemTime::now()};
+        let dt = Local::now();
+        let payload = QueueMessageEnvelope {id: uuid, body: message, created_at: dt};
         let json_payload = serde_json::to_value(&payload);
         let msg = json_payload.unwrap().to_string();
 
@@ -81,6 +82,7 @@ impl QueueManager {
     }
  
     fn publish_to_subscribers(&mut self, queue_name: String, message: String) {
+        // TODO: getting a key, reading from tb and broadcasting ? pop or last ?
         let mut online_subs: VecDeque<UnboundedSender<Bytes>> = VecDeque::new();
         let mut dirt = false;
 

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -5,13 +5,13 @@ use tokio::sync::mpsc::UnboundedReceiver;
 use actix_web::web::Bytes;
 use actix_web::{Result, Error};
 
-pub struct SubscriberChannel(pub UnboundedReceiver<Bytes>);
+pub struct SubscriberChannel(pub UnboundedReceiver<String>);
 
 impl Stream for SubscriberChannel {
     type Item = Result<Bytes, Error>;
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>, ) -> Poll<Option<Self::Item>> {
         match Pin::new(&mut self.0).poll_recv(cx) {
-            Poll::Ready(Some(v)) => Poll::Ready(Some(Ok(v))),
+            Poll::Ready(Some(v)) => Poll::Ready(Some(Ok(Bytes::from(v)))), // !!!
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
         }


### PR DESCRIPTION
- Shotgun surgery to fix Vec<u8> and String properly
- Bug hunting for the streaming handler binary download - turns out it was the side effect of bytes being serialised w bincode and actix playing out. Moved it back to String (as serde::json was throwing the json string out and http plays well w that).
- subscribers will get the message from the underslying database, notification honors the right key and there are the basics for offset management, latest/earliest positioning. It needs a good refactor on jumping from Vec<u8> to String and the overwall database -> http -> mpsc layer cleanup on the underlying data type